### PR TITLE
boost to std

### DIFF
--- a/src/Collision.cpp
+++ b/src/Collision.cpp
@@ -190,7 +190,7 @@ ConstraintPtr OpenSotCollisionConstraintAdapter::constructConstraint()
     Eigen::VectorXd q;
     _model->getJointPosition(q);
 
-    _opensot_coll = boost::make_shared<CollisionConstrSoT>(
+    _opensot_coll = std::make_shared<CollisionConstrSoT>(
                         q,
                         *_model,
                         _ci_coll->getSize(),


### PR DESCRIPTION
Hi,

I had a problem about:
```
/home/tori/TelePhysicalOperation/cartesio_collision_support/src/cartesio_collision_support/src/Collision.cpp:199:25: error: no match for ‘operator=’ (operand types are ‘OpenSoT::constraints::velocity::CollisionAvoidance::Ptr {aka std::shared_ptr<OpenSoT::constraints::velocity::CollisionAvoidance>}’ and ‘boost::detail::sp_if_not_array<OpenSoT::constraints::velocity::CollisionAvoidance>::type {aka boost::shared_ptr<OpenSoT::constraints::velocity::CollisionAvoidance>}’)
                         );
```
It seems that now `using CollisionConstrSoT = OpenSoT::constraints::velocity::CollisionAvoidance;` is a std pointer and not a boost pointer. 

I changed like this and with my xbot2 version (`version: 2.1.0 (f4f3a4d)`) compiles again
